### PR TITLE
Do not load the framework in settings unless expanded

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -28,9 +28,6 @@ require_once($CFG->dirroot . '/mod/hvp/lib.php');
 
 global $PAGE;
 
-// Make sure core is loaded.
-$core = \mod_hvp\framework::instance('core');
-
 // Redefine the H5P admin menu entry to be expandable.
 $modltifolder = new admin_category('modhvpfolder', new lang_string('pluginname', 'mod_hvp'), $module->is_enabled() === false);
 // Add the Settings admin menu entry.


### PR DESCRIPTION
The framework is loaded twice in settings.php file, the second time inside the `if ($ADMIN->fulltree)` where it is supposed to be. 
The removed code was executed on absolutely every page in the "Site administration" section and also on every page if the theme loads admin tree on other pages (which is the case with Moodle Workplace). 

This is a performance hit and also causes the https://github.com/h5p/moodle-mod_hvp/issues/347 to happen in the UI (on Boost it only happens in cron)