### PR TITLE
Add iframe title for screenreader users

### DIFF
--- a/classes/view_assets.php
+++ b/classes/view_assets.php
@@ -313,6 +313,7 @@ class view_assets {
      * Outputs h5p view
      */
     public function outputview() {
+        $title = s(strip_tags(format_string($this->content['title'])));
         if ($this->embedtype === 'div') {
             echo "<div class=\"h5p-content\" data-content-id=\"{$this->content['id']}\"></div>";
         } else {
@@ -325,6 +326,7 @@ class view_assets {
 
             echo "<div class=\"h5p-iframe-wrapper\">" .
                  "<iframe id=\"h5p-iframe-{$this->content['id']}\"" .
+                 " title=\"{$title}\"" .
                  " class=\"h5p-iframe\"" .
                  " data-content-id=\"{$this->content['id']}\"" .
                  " style=\"height:1px\"" .


### PR DESCRIPTION
Add title attribute to H5P iframe to give a mechanism that allows an accessible name value to be calculated.

I found this issue when scanning my organization's Moodle site for accessibility issues.

> Ensure frame titles are meaningful
> All frame elements in a document must provide valid title attributes. When frames are not titled, it becomes difficult for users of assistive technologies to move between frames in order to access the page content they wish to view. When a document provides untitled frames, assistive technology may instead choose to render other information to the user, such as the framed document's file name, in an attempt to help the user to understand the frame's purpose. In most instances, this is not likely to work, as the file's name may not be indicative of its purpose, nor descriptive of its content. Frames should contain meaningful and concise titles that directly reflect the content they represent and/or action to be performed by that frame.