### PR TITLE
Add string for grade.php

### DIFF
--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -191,6 +191,7 @@ $string['reportingscaledscoredelimiter'] = ',';
 $string['reportingquestionsremaininglabel'] = 'questions remaining to grade';
 $string['reportsubmitgradelabel'] = 'Submit grade';
 $string['noanswersubmitted'] = 'This user hasn\'t submitted an answer to the H5P yet';
+$string['nostudentsubmission'] = 'No student submission found';
 
 // Editor.
 $string['javascriptloading'] = 'Waiting for JavaScript...';


### PR DESCRIPTION
Add string language to reference when there is no student submission when accessing the Grade report.

As of now, it is hardcoded inside grade.php ( $title = "Results for {$hvp->title}"; ). I propose to use this string with a conditional whenever there is no student submission, otherwise shows the default variable content.

Reference #322 