### PR TITLE
Fix #338 improve cacheability of cachedassets

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -230,6 +230,17 @@ function hvp_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload
             return false; // Invalid file area.
 
         case 'libraries':
+            if ($context->contextlevel != CONTEXT_SYSTEM) {
+                return false; // Invalid context.
+            }
+
+            // Check permissions.
+            if (!has_capability('mod/hvp:getcachedassets', $context)) {
+                return false;
+            }
+
+            $itemid = 0;
+            break;
         case 'cachedassets':
             if ($context->contextlevel != CONTEXT_SYSTEM) {
                 return false; // Invalid context.
@@ -239,6 +250,9 @@ function hvp_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload
             if (!has_capability('mod/hvp:getcachedassets', $context)) {
                 return false;
             }
+
+            $options['cacheability'] = 'public';
+            $options['immutable'] = true;
 
             $itemid = 0;
             break;


### PR DESCRIPTION
Fix #338 - Makes the content that is served from the `cachedassets` file area public and immutable. 