### PR TITLE
Updated arguments of require_course_login function call for mobile view

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -53,7 +53,7 @@ class mobile {
         if (!$course) {
             print_error('coursemisconf');
         }
-        require_course_login($course, true, $cm);
+        require_course_login($course, false, $cm, true, true);
         $context = context_module::instance($cm->id);
         require_capability('mod/hvp:view', $context);
 


### PR DESCRIPTION
Me and my team recently received reports, that the H5P plugin does not function correctly when using the Moodle mobile app. After some research we found that the `tool_mfa` plugin throws a `redirecterrordetected` exception when trying to access H5P activities.

We traced the issue back to the `require_course_login` function call in the `/classes/output/mobile.php` file of this plugin. The function call does not include the `preventredirect` attribute which is something that most other plugins do in their mobile support functions and it is also done in the official Moodle mobile support for plugins documentation. This causes the problem described above to occur.