### PR TITLE
Remove extra whitespace from xmldb file

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -58,7 +58,7 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
       <INDEXES>
-        <INDEX NAME="results" UNIQUE="false" FIELDS="content_id, user_id" />
+        <INDEX NAME="results" UNIQUE="false" FIELDS="content_id, user_id"/>
       </INDEXES>
     </TABLE>
     <TABLE NAME="hvp_content_user_data" COMMENT="Stores user data about the content">


### PR DESCRIPTION
This causes Totara unit tests to fail the test which checks the file was generated through the xmldb editor.
I believe that mod_hvp will also fail tests when MDL-69051 is integrated as it's meant to be the same unit test that exists in Totara.