### PR TITLE
First try for a fix for #188

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -140,10 +140,15 @@ class framework implements \H5PFrameworkInterface {
         }
 
         // Get current language in Moodle.
-        $language = str_replace('_', '-', strtolower(\current_language()));
+        $languageCandidate = str_replace('_', '-', strtolower(\current_language()));
+        while ($languageCandidate != "" && !isset($map[$languageCandidate])) {
+            $parentLanguageString = new \lang_string("parentlanguage", "langconfig", null, $languageCandidate);
+            $parentLanguage = str_replace('_', '-', strtolower($parentLanguageString->out()));
+            if (!$parentLanguage) break;
+        }
 
         // Try to map.
-        return isset($map[$language]) ? $map[$language] : $language;
+        return isset($map[$languageCandidate]) ? $map[$languageCandidate] : $languageCandidate;
     }
 
     /**


### PR DESCRIPTION
- Try to get the base language (de from de_comm) or something like it and return that base language (this doesn't account for the possibility that H5P may have translations for de_comm, though)

We fixed our language problems this way, but I am aware that may not be the perfect solution for it, because there could be existing localisations for "sub"languages for hvp.