### PR TITLE
418 Fix completionpass NULLs

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -497,6 +497,9 @@ function hvp_upgrade_2020080400() {
 
 function hvp_upgrade_2020080401() {
     global $DB;
+    $DB->execute("UPDATE {hvp}
+                     SET completionpass = 0
+                   WHERE completionpass IS NULL");
     $dbman = $DB->get_manager();
 
     // Changing nullability of field completionpass on table hvp to not null.


### PR DESCRIPTION
If you had upgraded to mod_hvp version 2020080400 the
mdl_hvp.completionpass definition incorrectly allowed NULLs.  (If you
installed 2020080400 then mdl_hvp.completionpass did not allow NULLs).
The fix for #359 corrected this column definition but didn't change any
NULL values in the data resulting in error "column does not allow
NULLs" when trying to upgrade beyond 2020080400.  This commit changes
any NULLs in this column to 0 prior to the change of the column
definition to "not NULL".