### PR TITLE
Fix checks to match with core handling for allowframeemedding

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -27,7 +27,7 @@ class mobile {
         global $DB, $CFG, $OUTPUT, $USER;
 
         $cmid = $args['cmid'];
-        if (!$CFG->allowframembedding) {
+        if (empty($CFG->allowframembedding) && !\core_useragent::is_moodle_app()) {
             $context = \context_system::instance();
             if (has_capability('moodle/site:config', $context)) {
                 $template = 'mod_hvp/iframe_embedding_disabled';


### PR DESCRIPTION
Closes #424 

https://github.com/moodle/moodle/blob/036800d99debfe61dde45f61292bc5ad44ab7cb0/lib/weblib.php#L2284-L2287
States that it only passes the 'X-Frame-Options: sameorigin' setting if embedding is disabled AND if the user is not loading the page from the app.
```
    // The Moodle app must be allowed to embed content always.
    if (empty($CFG->allowframembedding) && !core_useragent::is_moodle_app()) {
        @header('X-Frame-Options: sameorigin');
    }
```

Tested using the official Moodle app, pointing to a local instance

<img src="https://user-images.githubusercontent.com/9924643/129995055-83d47aef-4ae8-4823-989a-13b1d8526e34.png"  height="400">
