### PR TITLE
Fix mobile app embedding display, which partially showed the content

### DIFF
--- a/templates/mobile_view_page.mustache
+++ b/templates/mobile_view_page.mustache
@@ -1,6 +1,8 @@
 {{=<% %>=}}
 <div style="height: 100%; width: 100%; background: white;">
     <iframe
+            width="100%"
+            height="100%"
             src="<% wwwroot %>/mod/hvp/embed.php?id=<% cmid %>&user_id=<% user_id %>&secret=<% secret %>"
             frameborder="0"
             allow="microphone; camera"


### PR DESCRIPTION
Closes #426

Related reading:
https://docs.moodle.org/dev/Moodle_App_Plugins_Development_Guide

Tested on mobile device (phone) using the Moodle App.

Tested working in the activity
<img src="https://user-images.githubusercontent.com/9924643/132445728-e252df82-77ed-43b7-b3b1-aadf978a7384.jpg" width=30% height=30%>

Tested working as an embed from the course page (embedded in a label)
<img src="https://user-images.githubusercontent.com/9924643/132445732-d32acf5c-9113-49ec-8c8e-853aa57a5575.jpg" width=30% height=30%>