### PR TITLE
Fix fetching shared content from the H5P hub

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -210,22 +210,7 @@ class framework implements \H5PFrameworkInterface {
             'CURLOPT_TIMEOUT'        => 300,
         );
 
-        if ($stream !== null) {
-            // Download file.
-            @set_time_limit(0);
-
-            // Generate local tmp file path.
-            $localfolder = $CFG->tempdir . uniqid('/hvp-');
-            $stream      = $localfolder . '.h5p';
-
-            // Add folder and file paths to H5P Core.
-            $interface = self::instance('interface');
-            $interface->getUploadedH5pFolderPath($localfolder);
-            $interface->getUploadedH5pPath($stream);
-
-            $stream                  = fopen($stream, 'w');
-            $options['CURLOPT_FILE'] = $stream;
-        }
+        @set_time_limit(0);
 
         $curl = new curl();
 
@@ -243,7 +228,23 @@ class framework implements \H5PFrameworkInterface {
         }
 
         if ($stream !== null) {
-            fclose($stream);
+            // Generate local tmp file path.
+            $localfolder = $CFG->tempdir . uniqid('/hvp-');
+            $stream = $localfolder . '.h5p';
+
+            // Add folder and file paths to H5P Core.
+            $interface = self::instance('interface');
+            $interface->getUploadedH5pFolderPath($localfolder);
+            $interface->getUploadedH5pPath($stream);
+
+            $written = file_put_contents($stream, $response);
+
+            if ($written === false) {
+                $response = false;
+            } else {
+                $response = true;
+            }
+
             @chmod($stream, $CFG->filepermissions);
         }
 


### PR DESCRIPTION
There is a bug in Moodle core ([MDL-73588](https://tracker.moodle.org/browse/MDL-73588)) that makes `CURLOPT_FILE` not working as expected in cases when redirects are involved and the redirecting pages actually generate some HTML output, too.

This bug affects H5P hub and it was not possible to fetch any shared content from it in recent Moodle versions.

As a workaround, this patch stops using the `CURLOPT_FILE` option at all.