### PR TITLE
MBS-4967: Adding check for index_exists to upgrade.php

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -524,14 +524,16 @@ function hvp_upgrade_2020082800() {
  * Drop old unused unique index, add nonunique index.
  */
 function hvp_upgrade_2020091500() {
-      global $DB;
-      $dbman = $DB->get_manager();
-      $table = new xmldb_table('hvp_xapi_results');
-      $index = new xmldb_index('results', XMLDB_INDEX_NOTUNIQUE, ['content_id', 'user_id']);
-      $dbman->add_index($table, $index);
+    global $DB;
+    $dbman = $DB->get_manager();
+    $table = new xmldb_table('hvp_xapi_results');
+    $index = new xmldb_index('results', XMLDB_INDEX_NOTUNIQUE, ['content_id', 'user_id']);
+    if (!$dbman->index_exists($table, $index)) {
+        $dbman->add_index($table, $index);
+    }
 
-      $oldindex = new xmldb_index('result', XMLDB_INDEX_UNIQUE, ['id', 'content_id', 'user_id']);
-      $dbman->drop_index($table, $oldindex);
+    $oldindex = new xmldb_index('result', XMLDB_INDEX_UNIQUE, ['id', 'content_id', 'user_id']);
+    $dbman->drop_index($table, $oldindex);
 }
 
 function hvp_upgrade_2020112600() {


### PR DESCRIPTION
We have set the index earlier and now have an upgrade problem. We would like to fix this problem so that others do not run into the same problem.
Also, it is best practice to first check if an index already exists.