### PR TITLE
Fix paths for update files. Fixes #453.

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -215,15 +215,15 @@ class framework implements \H5PFrameworkInterface {
             @set_time_limit(0);
 
             // Generate local tmp file path.
-            $localfolder = $CFG->tempdir . uniqid('/hvp-');
-            $stream      = $localfolder . '.h5p';
+            $localfolder = make_temp_directory(uniqid('hvp-'));
+            $localpath = $localfolder . '.h5p';
 
             // Add folder and file paths to H5P Core.
             $interface = self::instance('interface');
             $interface->getUploadedH5pFolderPath($localfolder);
-            $interface->getUploadedH5pPath($stream);
+            $interface->getUploadedH5pPath($localpath);
 
-            $stream                  = fopen($stream, 'w');
+            $stream = fopen($localpath, 'w');
             $options['CURLOPT_FILE'] = $stream;
         }
 
@@ -244,7 +244,7 @@ class framework implements \H5PFrameworkInterface {
 
         if ($stream !== null) {
             fclose($stream);
-            @chmod($stream, $CFG->filepermissions);
+            @chmod($localpath, $CFG->filepermissions);
         }
 
         $errorno = $curl->get_errno();


### PR DESCRIPTION
The previous code could result in a curl error if $CFG->tempdir didn't
already exist, and a chmod error if it did exist as it was being passed
$stream as a file resource rather than a string.