### PR TITLE
Add seperate title and description. Fixes #450

### DIFF
--- a/view.php
+++ b/view.php
@@ -50,6 +50,12 @@ $PAGE->set_url(new \moodle_url('/mod/hvp/view.php', array('id' => $id)));
 $PAGE->set_title(format_string($content['title']));
 $PAGE->set_heading($course->fullname);
 
+$PAGE->activityheader->set_attrs([
+    'title' => '',
+    'description' => '',
+]);
+
+
 // Add H5P assets to page.
 $view->addassetstopage();
 $view->logviewed();


### PR DESCRIPTION
The description is shown twice on the activity page when using the plugin on 4.0.x Moodle. The [upgrade.txt](https://github.com/moodle/moodle/blob/master/lib/upgrade.txt#L230) says that there needs to be title and description defined in the activityheader. 

![image](https://user-images.githubusercontent.com/6739027/177994059-85f6d520-ab34-49cb-9012-6dd1ca7157cd.png)