### PR TITLE
view_assets: fixed $options forceembedtype checking

### DIFF
--- a/classes/view_assets.php
+++ b/classes/view_assets.php
@@ -83,7 +83,7 @@ class view_assets {
             )
         );
 
-        $this->embedtype = isset($options->forceembedtype) ? $options->forceembedtype : \H5PCore::determineEmbedType(
+        $this->embedtype = isset($options['forceembedtype']) ? $options['forceembedtype'] : \H5PCore::determineEmbedType(
             $this->content['embedType'], $this->content['library']['embedTypes']
         );
 


### PR DESCRIPTION
$options used stdClass notation instead of associated array notation.