### PR TITLE
Update messages.php resolves #562

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -34,7 +34,7 @@ $messageproviders = array(
     'confirmation' => array(
         'capability' => 'mod/hvp:emailconfirmsubmission',
         'defaults' => array(
-            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         ),
     ),
 );


### PR DESCRIPTION
Resolves 4.5 compatibility - install failure [#562](https://github.com/h5p/moodle-mod_hvp/issues/562)

Replaced MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF to MESSAGE_DEFAULT_ENABLED as per Moodle plugin upgrade documentation: https://github.com/moodle/moodle/blob/13c12756b4d7e85f2d2e34038216179fd287c9c2/lib/upgrade.txt#L716

Thanks to @otacke and @lkcivan