### PR TITLE
AU-8017 Add option to re-upgrade subcontent

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1596,13 +1596,13 @@ class framework implements \H5PFrameworkInterface {
      * Implements getNumContent().
      */
     // @codingStandardsIgnoreLine
-    public function getNumContent($libraryid, $skip = NULL) {
+    public function getNumContent($libraryid, $skip = NULL, $lastid = 0) {
         global $DB;
         $skipquery = empty($skip) ? '' : " AND id NOT IN ($skip)";
 
         return (int) $DB->get_field_sql(
-                "SELECT COUNT(id) FROM {hvp} WHERE main_library_id = ?{$skipquery}",
-                array($libraryid));
+                "SELECT COUNT(id) FROM {hvp} WHERE main_library_id = ? AND id > ?{$skipquery}",
+                array($libraryid, $lastid));
     }
 
     /**

--- a/library_list.php
+++ b/library_list.php
@@ -28,6 +28,8 @@ require_once("locallib.php");
 // No guest autologin.
 require_login(0, false);
 
+$fixsubcontent = optional_param('fix_subcontent', false, PARAM_BOOL); // Special fix to re-run upgrade for subcontent only
+
 $pageurl = new moodle_url('/mod/hvp/library_list.php');
 $PAGE->set_url($pageurl);
 
@@ -67,11 +69,13 @@ $settings = array();
 $i = 0;
 foreach ($libraries as $versions) {
     foreach ($versions as $library) {
+        $numContent = $core->h5pF->getNumContent($library->id);
         $usage = $core->h5pF->getLibraryUsage($library->id, $numnotfiltered ? true : false);
         if ($library->runnable) {
             $upgrades = $core->getUpgrades($library, $versions);
-            $upgradeurl = empty($upgrades) ? false : (new moodle_url('/mod/hvp/upgrade_content_page.php', array(
-                'library_id' => $library->id
+            $upgradeurl = ($fixsubcontent ? empty($numContent) : empty($upgrades)) ? false : (new moodle_url('/mod/hvp/upgrade_content_page.php', array(
+                'library_id' => $library->id,
+                'fix_subcontent' => $fixsubcontent
             )))->out(false);
 
             $restricted = (isset($library->restricted) && $library->restricted == 1 ? true : false);
@@ -91,7 +95,7 @@ foreach ($libraries as $versions) {
             'title' => $library->title . ' (' . \H5PCore::libraryVersion($library) . ')',
             'restricted' => $restricted,
             'restrictedUrl' => $restrictedurl,
-            'numContent' => $core->h5pF->getNumContent($library->id),
+            'numContent' => $numContent,
             'numContentDependencies' => $usage['content'] === -1 ? '' : $usage['content'],
             'numLibraryDependencies' => $usage['libraries'],
             'upgradeUrl' => $upgradeurl,

--- a/locallib.php
+++ b/locallib.php
@@ -375,8 +375,13 @@ function hvp_content_upgrade_progress($libraryid) {
         $out->skipped = array();
     }
 
+    $lastid = filter_input(INPUT_POST, 'lastId');
+    if (empty($lastid) || $lastid != intval($lastid)) {
+        $lastid = 0;
+    }
+
     // Get number of contents for this library.
-    $out->left = $interface->getNumContent($libraryid, $skipped);
+    $out->left = $interface->getNumContent($libraryid, $skipped, $lastid);
 
     if ($out->left) {
         $skipquery = empty($skipped) ? '' : " AND id NOT IN ($skipped)";
@@ -388,8 +393,9 @@ function hvp_content_upgrade_progress($libraryid) {
                     a11y_title
                FROM {hvp}
               WHERE main_library_id = ?
+                AND id > ?
                     {$skipquery}
-           ORDER BY name ASC", array($libraryid), 0 , 40
+           ORDER BY id ASC", array($libraryid, $lastid), 0 , 40
         );
 
         foreach ($results as $content) {

--- a/locallib.php
+++ b/locallib.php
@@ -429,7 +429,7 @@ function hvp_get_library_upgrade_info($name, $major, $minor) {
         $response->upgradesScript = "{$basepath}pluginfile.php/{$context->id}/mod_hvp/libraries/{$libraryfoldername}/upgrades.js";
     }
     $response->semantics = $core->loadLibrarySemantics($name, $major, $minor);
-    
+
     return $response;
 }
 

--- a/locallib.php
+++ b/locallib.php
@@ -374,11 +374,7 @@ function hvp_content_upgrade_progress($libraryid) {
     } else {
         $out->skipped = array();
     }
-
-    $lastid = filter_input(INPUT_POST, 'lastId');
-    if (empty($lastid) || $lastid != intval($lastid)) {
-        $lastid = 0;
-    }
+    $lastid = optional_param('lastId', 0, PARAM_INT);
 
     // Get number of contents for this library.
     $out->left = $interface->getNumContent($libraryid, $skipped, $lastid);

--- a/upgrade_content_page.php
+++ b/upgrade_content_page.php
@@ -84,7 +84,7 @@ if (count($versions) < 2) {
                                  array('action' => 'getlibrarydataforupgrade')))->out(false) . '&library=',
             'scriptBaseUrl' => (new moodle_url('/mod/hvp/library/js'))->out(false),
             'buster' => hvp_get_cache_buster(),
-            'versions' => true ? [$libraryid => \H5PCore::libraryVersion($versions[$libraryid])] : $upgrades,
+            'versions' => $fixsubcontent ? [$libraryid => \H5PCore::libraryVersion($versions[$libraryid])] : $upgrades,
             'contents' => $numcontents,
             'buttonLabel' => get_string('upgradebuttonlabel', 'hvp'),
             'infoUrl' => (new moodle_url('/mod/hvp/ajax.php', array('action' => 'libraryupgradeprogress',

--- a/upgrade_content_page.php
+++ b/upgrade_content_page.php
@@ -91,7 +91,7 @@ if (count($versions) < 2) {
                           'library_id' => $libraryid)))->out(false),
             'total' => $numcontents,
             'token' => \H5PCore::createToken('contentupgrade'),
-            'fixSubContent' => !!$fixsubcontent,
+            'fixSubcontent' => !!$fixsubcontent,
         )
     );
 

--- a/upgrade_content_page.php
+++ b/upgrade_content_page.php
@@ -29,6 +29,7 @@ require_once("locallib.php");
 require_login(0, false);
 
 $libraryid = required_param('library_id', PARAM_INT);
+$fixsubcontent = optional_param('fix_subcontent', false, PARAM_BOOL); // Special fix to re-run upgrade for subcontent only
 $pageurl = new moodle_url('/mod/hvp/upgrade_content_page.php', array('library_id' => $libraryid));
 $PAGE->set_url($pageurl);
 admin_externalpage_setup('h5plibraries');
@@ -73,7 +74,7 @@ if (count($versions) < 2) {
             'errorTooHighVersion' => get_string('upgradeerrortoohighversion', 'hvp'),
             'errorNotSupported' => get_string('upgradeerrornotsupported', 'hvp'),
             'done' => get_string('upgradedone', 'hvp', $numcontents) .
-                      ' <a href="' . (new moodle_url('/mod/hvp/library_list.php'))->out(false) . '">' .
+                      ' <a href="' . (new moodle_url('/mod/hvp/library_list.php', array('fix_subcontent' => $fixsubcontent)))->out(false) . '">' .
                       get_string('upgradereturn', 'hvp') . '</a>',
             'library' => array(
                 'name' => $library->name,
@@ -83,13 +84,14 @@ if (count($versions) < 2) {
                                  array('action' => 'getlibrarydataforupgrade')))->out(false) . '&library=',
             'scriptBaseUrl' => (new moodle_url('/mod/hvp/library/js'))->out(false),
             'buster' => hvp_get_cache_buster(),
-            'versions' => $upgrades,
+            'versions' => true ? [$libraryid => \H5PCore::libraryVersion($versions[$libraryid])] : $upgrades,
             'contents' => $numcontents,
             'buttonLabel' => get_string('upgradebuttonlabel', 'hvp'),
             'infoUrl' => (new moodle_url('/mod/hvp/ajax.php', array('action' => 'libraryupgradeprogress',
                           'library_id' => $libraryid)))->out(false),
             'total' => $numcontents,
-            'token' => \H5PCore::createToken('contentupgrade')
+            'token' => \H5PCore::createToken('contentupgrade'),
+            'fixSubContent' => !!$fixsubcontent,
         )
     );
 


### PR DESCRIPTION
This fix adds a special query option to the libraries page that will trigger the content upgrade to re-run for already upgraded content, upgrading only the subcontent. This fixes content that was broken by previous content upgrades, as long as the broken content has **not** been edited and saved in the mean time.
Add query at end of URL to activate: /mod/hvp/library_list.php?**fix_subcontent=1**
Then click the Upgrade button next to the Content Type you wish to fix content for. You can only select the current version, but the process should otherwise run as normally. 
It does not keep track of the 'repair' progress, so reloading the page means starting the process from the first content again. 
The process will not make any to content that is working. But it has to go through all content to see if there is subcontent that isn't upgraded. 