### PR TITLE
MBS-10972: Remove redundant passing grade completion rule on Moodle 4.0+

### DIFF
--- a/backup/moodle2/restore_hvp_stepslib.php
+++ b/backup/moodle2/restore_hvp_stepslib.php
@@ -64,7 +64,7 @@ class restore_hvp_activity_structure_step extends restore_activity_structure_ste
      * @throws dml_exception
      */
     protected function process_hvp($data) {
-        global $DB;
+        global $CFG, $DB;
 
         $data = (object) $data;
         $data->course = $this->get_courseid();
@@ -77,6 +77,16 @@ class restore_hvp_activity_structure_step extends restore_activity_structure_ste
         $newitemid = $DB->insert_record('hvp', $data);
         // Immediately after inserting "activity" record, call this.
         $this->apply_activity_instance($newitemid);
+
+        // On Moodle 4.0+, migrate hvp completionpass to core completionpassgrade.
+        if ($CFG->branch >= 400 && !empty($data->completionpass)) {
+            $moduleid = $DB->get_field('modules', 'id', ['name' => 'hvp']);
+            $where = [
+                'instance' => $newitemid,
+                'module' => $moduleid,
+            ];
+            $DB->set_field('course_modules', 'completionpassgrade', 1, $where);
+        }
     }
 
     /**

--- a/classes/task/migrate_completionpass.php
+++ b/classes/task/migrate_completionpass.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_hvp\task;
+
+/**
+ * Migrate from hvp.completionpass to course_modules.completionpassgrade on Moodle 4.0+.
+ *
+ * The plugin upgrade step runs one time, when the plugin is upgraded, so a site
+ * that upgrades the plugin while on Moodle < 4.0 then later upgrades to Moodle
+ * 4.0+ would never migrate its data. This ad-hoc task is queued by the upgrade
+ * step (and re-queues itself) until it runs on Moodle 4.0+ and performs the
+ * migration.
+ *
+ * @package    mod_hvp
+ * @copyright  2026 H5P Group
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class migrate_completionpass extends \core\task\adhoc_task {
+    public function get_name() {
+        return get_string('migratecompletionpass', 'mod_hvp');
+    }
+
+    public function execute() {
+        self::migrate();
+    }
+
+    /**
+     * Migrate legacy hvp.completionpass values to course_modules.completionpassgrade.
+     *
+     * On Moodle < 4.0 the core field does not exist yet, so an ad-hoc task is
+     * queued to retry the migration later instead.
+     */
+    public static function migrate() {
+        global $CFG, $DB;
+
+        // Moodle too old, try again later.
+        if ($CFG->branch < 400) {
+            $task = new self();
+            $task->set_next_run_time(time() + HOURSECS);
+            \core\task\manager::queue_adhoc_task($task, true);
+            return;
+        }
+
+        $moduleid = $DB->get_field('modules', 'id', ['name' => 'hvp']);
+        if (!$moduleid) {
+            return;
+        }
+
+        $sql = "UPDATE {course_modules} cm
+                   SET cm.completionpassgrade = 1
+                 WHERE cm.module = :moduleid
+                   AND cm.instance IN (
+                       SELECT h.id
+                         FROM {hvp} h
+                        WHERE h.completionpass = 1
+                   )";
+        $DB->execute($sql, ['moduleid' => $moduleid]);
+    }
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -576,6 +576,30 @@ function hvp_upgrade_2026050600() {
 }
 
 /**
+ * Migrate from hvp.completionpass to course_modules.completionpassgrade.
+ */
+function hvp_upgrade_2026081900() {
+    global $DB, $CFG;
+
+    // Moodle 4.0 added course_modules.completionpassgrade.
+    if ($CFG->branch < 400) {
+        return;
+    }
+
+    $moduleid = $DB->get_field('modules', 'id', ['name' => 'hvp']);
+
+    $sql = "UPDATE {course_modules} cm
+               SET cm.completionpassgrade = 1
+             WHERE cm.module = :moduleid
+               AND cm.instance IN (
+                   SELECT h.id
+                     FROM {hvp} h
+                    WHERE h.completionpass = 1
+               )";
+    $DB->execute($sql, ['moduleid' => $moduleid]);
+}
+
+/**
  * Hvp module upgrade function.
  *
  * @param string $oldversion The version we are upgrading from
@@ -602,6 +626,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2020091500,
         2020112600,
         2026050600,
+        2026081900,
     ];
 
     foreach ($upgrades as $version) {

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -577,26 +577,11 @@ function hvp_upgrade_2026050600() {
 
 /**
  * Migrate from hvp.completionpass to course_modules.completionpassgrade.
+ *
+ * Note: On Moodle sites < 4.0, the migration will happen when possible.
  */
 function hvp_upgrade_2026081900() {
-    global $DB, $CFG;
-
-    // Moodle 4.0 added course_modules.completionpassgrade.
-    if ($CFG->branch < 400) {
-        return;
-    }
-
-    $moduleid = $DB->get_field('modules', 'id', ['name' => 'hvp']);
-
-    $sql = "UPDATE {course_modules} cm
-               SET cm.completionpassgrade = 1
-             WHERE cm.module = :moduleid
-               AND cm.instance IN (
-                   SELECT h.id
-                     FROM {hvp} h
-                    WHERE h.completionpass = 1
-               )";
-    $DB->execute($sql, ['moduleid' => $moduleid]);
+    \mod_hvp\task\migrate_completionpass::migrate();
 }
 
 /**

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -69,6 +69,7 @@ $string['updatelibraries'] = 'Update All Libraries';
 $string['removetmpfiles'] = 'Remove old H5P temporary files';
 $string['removeoldlogentries'] = 'Remove old H5P log entries';
 $string['removeoldmobileauthentries'] = 'Remove old H5P mobile auth entries';
+$string['migratecompletionpass'] = 'Migrate H5P passing grade completion settings';
 
 // Admin settings.
 $string['displayoptiondownloadnever'] = 'Never';

--- a/lib.php
+++ b/lib.php
@@ -47,6 +47,8 @@ require_once('autoloader.php');
  * @return mixed true if the feature is supported, null if unknown
  */
 function hvp_supports($feature) {
+    global $CFG;
+
     switch($feature) {
         case FEATURE_GROUPS:
             return true;
@@ -57,7 +59,8 @@ function hvp_supports($feature) {
         case FEATURE_COMPLETION_TRACKS_VIEWS:
             return true;
         case FEATURE_COMPLETION_HAS_RULES:
-            return true;
+            // Moodle 4.0+ has its own passing grade completion rule.
+            return ($CFG->branch < 400);
         case FEATURE_GRADE_HAS_GRADE:
             return true;
         case FEATURE_GRADE_OUTCOMES:
@@ -450,6 +453,12 @@ function hvp_update_grades($hvp=null, $userid=0, $nullifnone=true) {
  */
 function hvp_get_completion_state($course, $cm, $userid, $type) {
     global $DB, $CFG;
+
+    // On Moodle 4.0+, use the core passing grade rule.
+    if ($CFG->branch >= 400) {
+        return $type;
+    }
+
     $hvp = $DB->get_record('hvp', array('id' => $cm->instance), '*', MUST_EXIST);
     if (!$hvp->completionpass) {
         return $type;

--- a/mod_form.php
+++ b/mod_form.php
@@ -171,7 +171,7 @@ class mod_hvp_mod_form extends moodleform_mod {
     }
 
     public function data_preprocessing(&$defaultvalues) {
-        global $DB;
+        global $CFG, $DB;
         $core = \mod_hvp\framework::instance();
 
         $content = null;
@@ -205,8 +205,8 @@ class mod_hvp_mod_form extends moodleform_mod {
         }
         $defaultvalues['h5pparams'] = json_encode($maincontentdata, true);
 
-        // Completion settings check.
-        if (empty($defaultvalues['completionusegrade'])) {
+        // Completion settings check (Moodle < 4.0).
+        if ($CFG->branch < 400 && empty($defaultvalues['completionusegrade'])) {
             $defaultvalues['completionpass'] = 0; // Forced unchecked.
         }
 
@@ -320,6 +320,8 @@ class mod_hvp_mod_form extends moodleform_mod {
      * @return array
      */
     public function validation($data, $files) {
+        global $CFG;
+
         $errors = parent::validation($data, $files);
 
         // Validate max grade as a non-negative numeric value.
@@ -335,7 +337,8 @@ class mod_hvp_mod_form extends moodleform_mod {
             $this->validate_created($data, $errors);
         }
 
-        if (array_key_exists('completion', $data) && $data['completion'] == COMPLETION_TRACKING_AUTOMATIC) {
+        // Validate the custom completion rule on Moodle versions before 4.0.
+        if ($CFG->branch < 400 && isset($data['completion']) && $data['completion'] == COMPLETION_TRACKING_AUTOMATIC) {
             $completionpass = isset($data['completionpass']) ? $data['completionpass'] : $this->current->completionpass;
             // Show an error if require passing grade was selected and the grade to pass was set to 0.
             if ($completionpass && (empty($data['gradepass']) || grade_floatval($data['gradepass']) == 0)) {
@@ -438,21 +441,19 @@ class mod_hvp_mod_form extends moodleform_mod {
 
         $mform   =& $this->_form;
 
-        // Changes for Moodle 4.3 - MDL-78516.
-        if ($CFG->branch < 403) {
-            $suffix = '';
-        } else {
-            $suffix = $this->get_suffix();
+        // Moodle 4.0+ provides its own "Require passing grade" completion rule.
+        if ($CFG->branch >= 400) {
+            return array();
         }
 
         $items   = array();
         $group   = array();
-        $group[] = $mform->createElement('advcheckbox', 'completionpass' . $suffix, null, get_string('completionpass', 'hvp'),
+        $group[] = $mform->createElement('advcheckbox', 'completionpass', null, get_string('completionpass', 'hvp'),
             array('group' => 'cpass'));
-        $mform->disabledIf('completionpass' . $suffix, 'completionusegrade', 'notchecked');
-        $mform->addGroup($group, 'completionpassgroup' . $suffix, get_string('completionpass', 'hvp'), ' &nbsp; ', false);
-        $mform->addHelpButton('completionpassgroup' . $suffix, 'completionpass', 'hvp');
-        $items[] = 'completionpassgroup' . $suffix;
+        $mform->disabledIf('completionpass', 'completionusegrade', 'notchecked');
+        $mform->addGroup($group, 'completionpassgroup', get_string('completionpass', 'hvp'), ' &nbsp; ', false);
+        $mform->addHelpButton('completionpassgroup', 'completionpass', 'hvp');
+        $items[] = 'completionpassgroup';
 
         return $items;
     }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->version   = 2026081900;
-$plugin->requires  = 2013051403;
+$plugin->requires  = 2014051200;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026081300;
+$plugin->version   = 2026081900;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.28.3';
+$plugin->release   = '1.28.4';


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
Completion settings show confusing duplicate "passing grade" checkboxes.

**What is the new behaviour?**

- Completion settings on Moodle 4.0+ only show the core "passing grade" checkbox.
- Existing activities automatically convert from legacy `hvp.completionpass` to `course_modules.completionpassgrade`.
- Restored activities automatically convert from legacy `hvp.completionpass` to `course_modules.completionpassgrade`.

**Important notes**
Required minimum Moodle version was corrected to 2.7 so that it matches the pre-existing, code-based requirements that already exist in this plugin: frankenstyle class auto-loading (requires 2.6) and the task API (requires 2.7).

Every decision was carefully made, because I want this to be as simple as possible to merge, so any complexity has very good reasons that I would be happy to discuss/document further. If Moodle 4.0 was the minimum, a significant amount of the complexity evaporates, but that is not my decision to make. 😅 

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally