### PR TITLE
Extend backup/restore to include xAPI results, resolves #316.

### DIFF
--- a/backup/moodle2/backup_hvp_stepslib.php
+++ b/backup/moodle2/backup_hvp_stepslib.php
@@ -84,10 +84,27 @@ class backup_hvp_activity_structure_step extends backup_activity_structure_step 
             'delete_on_content_change',
         ));
 
+        // xAPI results.
+        $xapiresults = new backup_nested_element('xapi_results');
+        $xapiresult = new backup_nested_element('xapi_result', ['id'], [
+            'user_id', // Annotated.
+            'parent_id',
+            'interaction_type',
+            'description',
+            'correct_responses_pattern',
+            'response',
+            'additionals',
+            'raw_score',
+            'max_score',
+        ]);
+
         // Build the tree.
 
         $hvp->add_child($entries);
         $entries->add_child($contentuserdata);
+
+        $hvp->add_child($xapiresults);
+        $xapiresults->add_child($xapiresult);
 
         // Define sources.
 
@@ -124,10 +141,15 @@ class backup_hvp_activity_structure_step extends backup_activity_structure_step 
         // All the rest of elements only happen if we are including user info.
         if ($userinfo) {
             $contentuserdata->set_source_table('hvp_content_user_data', array('hvp_id' => backup::VAR_PARENTID));
+
+            // The content_id of the xAPI results equals the hvp record id.
+            // Order it by id so parent rows are backed up before their children.
+            $xapiresult->set_source_table('hvp_xapi_results', ['content_id' => backup::VAR_PARENTID], 'id ASC');
         }
 
         // Define id annotations.
         $contentuserdata->annotate_ids('user', 'user_id');
+        $xapiresult->annotate_ids('user', 'user_id');
         // In an ideal world we would use the main_library_id and annotate that
         // but since we cannot know the required dependencies of the content
         // without parsing json_content and crawling the libraries_libraries

--- a/backup/moodle2/restore_hvp_stepslib.php
+++ b/backup/moodle2/restore_hvp_stepslib.php
@@ -34,6 +34,14 @@ defined('MOODLE_INTERNAL') || die();
 class restore_hvp_activity_structure_step extends restore_activity_structure_step {
 
     /**
+     * Keeps track of the old parent_id of every restored xAPI result so it can
+     * be remapped to the new id once all results have been restored.
+     *
+     * @var array
+     */
+    protected $xapiresultparents = array();
+
+    /**
      * Defines restore element's structure
      *
      * @return array
@@ -49,6 +57,9 @@ class restore_hvp_activity_structure_step extends restore_activity_structure_ste
         if ($userinfo) {
             // Restore content state.
             $paths[] = new restore_path_element('content_user_data', '/activity/hvp/content_user_data/entry');
+
+            // Restore xAPI results.
+            $paths[] = new restore_path_element('xapi_result', '/activity/hvp/xapi_results/xapi_result');
         }
 
         // Return the paths wrapped into standard activity structure.
@@ -97,14 +108,58 @@ class restore_hvp_activity_structure_step extends restore_activity_structure_ste
     }
 
     /**
+     * Process and inserts an xAPI result.
+     *
+     * The parent_id is a self-reference to another hvp_xapi_results record, so
+     * it cannot be remapped here (the parent may not have been restored yet).
+     * It is stored and remapped in after_execute().
+     *
+     * @param $data
+     *
+     * @throws dml_exception
+     */
+    protected function process_xapi_result($data) {
+        global $DB;
+
+        $data = (object) $data;
+        $oldid = $data->id;
+        unset($data->id);
+
+        $data->user_id = $this->get_mappingid('user', $data->user_id);
+        $data->content_id = $this->get_new_parentid('hvp');
+
+        // Remember the original parent_id so it can be remapped afterwards.
+        $oldparentid = $data->parent_id;
+        $data->parent_id = null;
+
+        $newid = $DB->insert_record('hvp_xapi_results', $data);
+        $this->set_mapping('hvp_xapi_result', $oldid, $newid);
+
+        if (!empty($oldparentid)) {
+            $this->xapiresultparents[$newid] = $oldparentid;
+        }
+    }
+
+    /**
      * Additional work that needs to be done after steps executions.
      */
     protected function after_execute() {
+        global $DB;
+
         // Add files for intro field.
         $this->add_related_files('mod_hvp', 'intro', null);
 
         // Add hvp related files.
         $this->add_related_files('mod_hvp', 'content', 'hvp');
+
+        // Now that all xAPI results have been restored, remap the parent_id of
+        // sub content results to the new record ids.
+        foreach ($this->xapiresultparents as $newid => $oldparentid) {
+            $newparentid = $this->get_mappingid('hvp_xapi_result', $oldparentid);
+            if ($newparentid) {
+                $DB->set_field('hvp_xapi_results', 'parent_id', $newparentid, ['id' => $newid]);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
xAPI results backup/restore.

**What is the current behaviour?**
#316

**What is the new behaviour?**
xAPI results are included in backup and restore, keeping user detailed interactions.

## PR Checklist

Before submitting, please confirm:

- [X] I searched for existing issues/PRs first
- [X] I linked related issues/discussions
- [X] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.